### PR TITLE
Fix CI error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,30 +5,27 @@ on: [push, pull_request]
 jobs:
   format:
     name: Code formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
-          otp-version: 22.2
-          elixir-version: "1.10"
+          otp-version: '22.2'
+          elixir-version: '1.10'
 
       - name: Check format
         run: mix format --check-formatted
 
   test:
-    name: Test suite
-    runs-on: ubuntu-latest
-
+    name: Test suite OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        pair:
-          - erlang: 22.3
-            elixir: "1.10"
-
+        otp: ['22.3']
+        elixir: ['1.10']
     env:
       MIX_ENV: test
 
@@ -36,10 +33,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.pair.erlang }}
-          elixir-version: ${{ matrix.pair.elixir }}
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
 
       - name: Install dependencies
         run: mix deps.get


### PR DESCRIPTION
This PR fixes this error I see in actions:

```
Run actions/setup-elixir@v1
Installing OTP 22.2 - built on ubuntu-14.04
Installing Elixir v1.10.4
/home/runner/work/_temp/.setup-elixir/elixir/bin/mix local.rebar --force
/home/runner/work/_temp/.setup-elixir/otp/erts-10.6/bin/beam.smp: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
Error: The process '/home/runner/work/_temp/.setup-elixir/elixir/bin/mix' failed with exit code 127
```